### PR TITLE
Fixed null reference when no active file is open

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,10 @@ analysis.indexing.subscribe(files => {
 function lupaMiddleware(store) {
     return (next) => (action) => {
         if (action.type == 'indexProject') {
-            const currentFile = store.getState().activeFile.path;
-            analysis.indexProject(Path.dirname(currentFile));
+            const activeFile = store.getState().activeFile;
+            if (activeFile) {
+                analysis.indexProject(Path.dirname(activeFile.path));
+            }
         }
         if (action.type == 'setActiveFile') {
             const contents = action.file.contents;


### PR DESCRIPTION
```
TypeError: Cannot read property 'path' of undefined
    at /Users/anri/.atom/packages/atom-lupa/index.js:56:60
    at /Users/anri/.atom/packages/atom-lupa/lib/middleware/domMiddleware.js:22:9
```
